### PR TITLE
Fix build issues with bs58 typings and webpack config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,18 +1,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  webpack(cfg){
-    cfg.experiments = { ...cfg.experiments, asyncWebAssembly:true }
+  webpack(cfg) {
+    cfg.experiments = { ...cfg.experiments, asyncWebAssembly: true };
     cfg.module.rules.push({
-      test:/\.wasm$/,
-      type:'webassembly/async'
-    })
-    return cfg
+      test: /\.wasm$/,
+      type: 'webassembly/async',
+    });
+    // tiny-secp256k1 が Node の組込みモジュールを参照しないようポリフィル
+    cfg.resolve = {
+      ...cfg.resolve,
+      fallback: { fs: false, path: false, os: false },
+    };
+    return cfg;
   },
-  // tiny-secp256k1 が Node の組込みモジュールを参照しないようポリフィル
-  resolve: {
-    fallback: { fs:false, path:false, os:false }
-  },
-  devIndicators: false,
   async rewrites() {
     return [
       {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -13,3 +13,6 @@ declare module 'ecpair' {
   const factory: any;
   export { factory as ECPairFactory };
 }
+
+// 追加: bs58 を型定義なしで扱えるよう宣言
+declare module 'bs58';


### PR DESCRIPTION
## Summary
- update `next.config.js` to move fallback settings inside `webpack` and remove invalid `devIndicators`
- declare the `bs58` module in `src/types/global.d.ts`

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684137b7d47c8324a6a0e5abf7db893f