### PR TITLE
Add calcFP unit test

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'jest';
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
+};
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,3 @@
+if (typeof global.btoa === 'undefined') {
+  global.btoa = (data: string) => Buffer.from(data, 'binary').toString('base64');
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "@account-abstraction/sdk": "^0.6.0",
@@ -48,6 +49,7 @@
     "jest": "^29.7.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ts-jest": "^29.3.4"
   }
 }

--- a/tests/fingerprint.test.ts
+++ b/tests/fingerprint.test.ts
@@ -1,0 +1,7 @@
+import { calcFP } from '../src/utils/fingerprint';
+
+test('calcFP generates expected fingerprint', async () => {
+  await expect(calcFP('TestInput')).resolves.toBe(
+    '4LdZ8zau/S/1sxU08j2Yzt/cpAeFC6XGyZUCxCREGrc='
+  );
+});


### PR DESCRIPTION
## Summary
- configure Jest and polyfill `btoa`
- add unit test for `calcFP`
- expose `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841074a999c832485d4e1e2d907411b